### PR TITLE
remove reference to KC (temporarily)

### DIFF
--- a/charts/ibm-odm-metering/README.md
+++ b/charts/ibm-odm-metering/README.md
@@ -4,9 +4,7 @@ The [IBM Operational Decision Manager metering service](https://github.com/ODMDe
 
 ## Introduction
 
-The IBM License Metering Tool (ILMT) provides information about the usage of decision artifacts and executed decisions. Users of subscription services can obtain details about these billable artifacts. The license covers consumption in the form of traffic between RuleApps and client applications.
-
-For more information, see the [Operational Decision Manager documentation](https://www.ibm.com/support/knowledgecenter/SSQP76_8.10.x/com.ibm.odm.kube/topics/con_k8s_licensing_metering.html).
+The [IBM License Metering Tool (ILMT)](https://www.ibm.com/support/knowledgecenter/SS8JFY_9.2.0/com.ibm.lmt.doc/welcome/LMT_welcome.html?view=kc) provides information about the usage of decision artifacts and executed decisions. Users of subscription services can obtain details about these billable artifacts. The license covers consumption in the form of traffic between RuleApps and client applications.
 
 ## Chart Details
 
@@ -367,6 +365,4 @@ priority: 0
 
 Only one pod can be instanciated for the metering service.
 
-## Documentation
 
-For more information, see [ODM documentation](https://www.ibm.com/support/knowledgecenter/SSQP76_8.10.x/com.ibm.odm.kube/topics/con_k8s_licensing_metering.html).


### PR DESCRIPTION
[Licensing and metering](https://www.ibm.com/support/knowledgecenter/SSQP76_8.10.x/com.ibm.odm.kube/topics/con_k8s_licensing_metering.html) topic in KC will be refreshed end of June.